### PR TITLE
Removed password confirmation on registration page

### DIFF
--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { loginValidationSchema } from '@/utils/validationSchema'
+import { loginValidationSchema, registerValidationSchema } from '@/utils/validationSchema'
 
 export type UserResponse = {
   createdAt: string
@@ -11,11 +11,6 @@ export type UserResponse = {
   updatedAt: string
 }
 
-export type NewUser = {
-  name: string
-  email: string
-  password: string
-  passwordConfirmation: string
-}
+export type NewUser = z.infer<typeof registerValidationSchema>
 
 export type LoginCredentials = z.infer<typeof loginValidationSchema>

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -1,27 +1,22 @@
+import { zodResolver } from '@hookform/resolvers/zod'
 import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
 import Container from '@mui/material/Container'
 import Typography from '@mui/material/Typography'
 import { NextPageContext } from 'next'
-import { useState } from 'react'
+import Image from 'next/image'
+import { useForm, SubmitHandler } from 'react-hook-form'
 
 import { Button } from '@/components/elements/Button'
-import { TextField } from '@/components/elements/TextField/TextField'
+import { RHFTextField } from '@/components/elements/TextField/RHFTextField'
 import { useRegister } from '@/features/auth/hooks/useRegister'
 import { NewUser } from '@/features/auth/types'
 import cookies from '@/utils/cookies'
-
-const boxStyles = {
-  width: '600px',
-  margin: 'auto',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  gap: '40px',
-}
+import { registerValidationSchema } from '@/utils/validationSchema'
 
 export function getServerSideProps(ctx: NextPageContext) {
-  const currentUserId = cookies.get(ctx).current_user_id
-  if (currentUserId) {
+  const authToken = cookies.get(ctx).token
+  if (authToken) {
     return {
       redirect: {
         destination: '/',
@@ -31,70 +26,85 @@ export function getServerSideProps(ctx: NextPageContext) {
   }
 
   return {
-    props: {},
+    props: { isLoginPage: true },
   }
 }
 
-const Register = () => {
-  const { isLoading, mutate } = useRegister()
+const cardStyles = {
+  display: 'flex',
+  flexDirection: 'column',
+  margin: 'auto',
+  marginY: '100px',
+  padding: '25px',
+  width: '30%',
+}
+const boxStyles = { display: 'flex', margin: 'auto', paddingBottom: '20px' }
+const typographyStyles = { color: '#26a69a', fontWeight: 'bold', textAlign: 'center' }
+const formStyles = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '293px',
+  justifyContent: 'space-between',
+}
 
-  const [name, setName] = useState<string>('')
-  const [email, setEmail] = useState<string>('')
-  const [password, setPassword] = useState<string>('')
-  const [passwordConfirmation, setPasswordConfirmation] = useState<string>('')
-  const newUser: NewUser = {
-    name,
-    email,
-    password,
-    passwordConfirmation,
-  }
+const Register = () => {
+  const { control, handleSubmit } = useForm<NewUser>({
+    mode: 'onChange',
+    resolver: zodResolver(registerValidationSchema),
+  })
+  const { isLoading, mutate } = useRegister()
+  const onSubmit: SubmitHandler<NewUser> = (data) => mutate(data)
 
   return (
-    <Container sx={{ paddingY: '40px' }}>
-      <Box sx={boxStyles}>
-        <Typography sx={{ textAlign: 'center', fontWeight: 'bold', fontSize: 25 }} gutterBottom>
-          会員登録
-        </Typography>
-
-        <TextField
-          id='name'
-          label='お名前'
-          onChange={(e) => setName(e.target.value)}
-          type='text'
-          sx={{ width: '100%' }}
-        />
-        <TextField
-          id='email'
-          label='メール'
-          onChange={(e) => setEmail(e.target.value)}
-          type='email'
-          sx={{ width: '100%' }}
-        />
-        <TextField
-          id='password'
-          label='パスワード'
-          onChange={(e) => setPassword(e.target.value)}
-          type='password'
-          sx={{ width: '100%' }}
-        />
-        <TextField
-          id='password-confirmation'
-          label='パスワード（確認用）'
-          onChange={(e) => setPasswordConfirmation(e.target.value)}
-          type='password'
-          sx={{ width: '100%' }}
-        />
-        <Button
-          variant='contained'
-          isLoading={isLoading}
-          onClick={() => {
-            mutate(newUser)
-          }}
-          sx={{ width: '100%', height: '56px' }}
-        >
-          会員登録
-        </Button>
-      </Box>
+    <Container>
+      <Card sx={cardStyles}>
+        <Box sx={boxStyles}>
+          <Image
+            alt='tamemo_logo'
+            height={35}
+            src='tamemo-primary.svg'
+            style={{ marginRight: '10px' }}
+            width={35}
+          />
+          <Typography component='h5' sx={typographyStyles} variant='h5'>
+            tamemo
+          </Typography>
+        </Box>
+        <Box component='form' onSubmit={handleSubmit(onSubmit)} sx={formStyles}>
+          <RHFTextField
+            control={control}
+            id='name'
+            label='ユーザー名'
+            name='name'
+            sx={{ width: '100%' }}
+            type='text'
+          />
+          <RHFTextField
+            control={control}
+            id='email'
+            label='メール'
+            name='email'
+            sx={{ width: '100%' }}
+            type='email'
+          />
+          <RHFTextField
+            control={control}
+            id='password'
+            label='パスワード'
+            name='password'
+            sx={{ width: '100%' }}
+            type='password'
+          />
+          <Button
+            isLoading={isLoading}
+            sx={{ width: '100%', height: '56px' }}
+            type='submit'
+            variant='contained'
+          >
+            会員登録
+          </Button>
+        </Box>
+      </Card>
     </Container>
   )
 }

--- a/src/utils/validationSchema.ts
+++ b/src/utils/validationSchema.ts
@@ -9,3 +9,16 @@ export const loginValidationSchema = z.object({
     .string({ required_error: 'パスワードを入力してください' })
     .min(1, { message: 'パスワードを入力してください' }),
 })
+
+export const registerValidationSchema = z.object({
+  name: z
+    .string({ required_error: 'ユーザー名を入力してください' })
+    .min(1, { message: 'ユーザー名を入力してください' }),
+  email: z
+    .string({ required_error: 'メールアドレスを入力してください' })
+    .min(1, { message: 'メールアドレスを入力してください' })
+    .email({ message: 'メールアドレスを正しく入力してください' }),
+  password: z
+    .string({ required_error: 'パスワードを入力してください' })
+    .min(1, { message: 'パスワードを入力してください' }),
+})


### PR DESCRIPTION
# summary
Deleted because the need for password confirmation is reduced due to the presence of the Show Password button.

### front-end(Next.js)
Removed text field for password confirmation from user registration page

### backend(rails API)
If the value of password_confirmation in has_secure_password is set to nil, the validation will pass.
reference:https://qiita.com/sasakura_870/items/8a087eb156f0b883f89a

In addition, I added a zod verification schema for the registration page.